### PR TITLE
Fix infinite loop calling OutputBox.shutdown(). Version bump.

### DIFF
--- a/qtutils/outputbox.py
+++ b/qtutils/outputbox.py
@@ -347,11 +347,8 @@ class OutputBox(object):
         self.write("shutdown")
         self.mainloop_thread.join()
         # Print queued text to the box until there is none left:
-        while True:
-            try:
-                self.add_text()
-            except queue.Empty:
-                break
+        while not self._text_queue.empty():
+            self.add_text()
         self.shutting_down = False
 
     # Ensure instances can be treated as a file-like object:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if 'REBUILD' in sys.argv:
     sys.argv.remove('REBUILD')
     REBUILD = True
 
-VERSION = '2.3.1'
+VERSION = '2.3.2'
 
 # conditional for readthedocs environment
 on_rtd = os.environ.get('READTHEDOCS') == 'True'


### PR DESCRIPTION
BLACS isn't calling OutputBox.shutdown() every time it restarts a tab, leading to a memory leak since each outputbox has its own thread that keeps objects alive.

In fixing that issue I found that shutdown is actually broken and gets stuck in an infinite loop. This fixes that. Once merged I'll tag and make a PyPI upload, and have the BLACS change that fixes the memory leak depend on it.