### PR TITLE
Do not include run_exports from pyqt as a run-time dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 #
 qtutils/icons/_icons_pyqt5.py
 qtutils/icons/_icons_pyside2.py
-
+conda_packages/
+conda_build/
 #
 # General puprose ignore rules
 #

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,9 @@ pyside = PySide2
 conda_name_differences = PyQt5:pyqt
 # For build requirements - PySide2 is only in conda-forge.
 channels = conda-forge
+ignore_run_exports = 
+    pyqt
+    # Note: python_abi can be removed once setuptools-conda depends on conda-build >=
+    # 3.18.12 (which it will once that version lands in the conda repositories)
+    # see https://gitter.im/conda/conda-build?at=5e7251004aec312c1f8ef3c4
+    python_abi


### PR DESCRIPTION
the pyqt conda package lists itself under its `run_exports`, which
means that it is automatically considered a run-time dependency of any
package of which it is a build dependency. Moreover, the run-time
dependency is pinned to the specific version of PyQt used during the
build, which would be excessive even if it were a run-time requirement we actually wanted.

setuptools-conda 0.6.7 adds an argument for passing a list of packages
to the ignore_run_exports section of the recipe, so we use that to
ensure pyqt is not a run-time dependency.

Also, due to some strangeness on conda-forge (required for PySide2
during the build), the python_abi of the specific Python package used
during the build is being included as a run-time dependency. Ignore it
as well. It sounds like this can be removed once a newer version of
conda-build is in the conda repositories that resolves the issue.