### PR TITLE
Fix for pip install -e and setup.py develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,42 @@ from setuptools import setup
 import os
 from pathlib import Path
 from subprocess import check_call
-import setuptools.command.build_py
+from setuptools.command.build_py import build_py
+from setuptools.command.develop import develop
 
 
-class build_py(setuptools.command.build_py.build_py):
+def build_icons(target_dir):
+    icons_pyqt5 = target_dir / '_icons_pyqt5.py'
+    icons_pyside2 = target_dir / '_icons_pyside2.py'
+    qrc_file = Path('icons', 'icons.qrc')
+    check_call(['pyrcc5', '-o', str(icons_pyqt5), str(qrc_file)])
+    check_call(['pyside2-rcc', '-o', str(icons_pyside2), str(qrc_file)])
+
+
+class custom_build_py(build_py):
     def run(self):
         if not self.dry_run:
             target_dir = Path(self.build_lib) / 'qtutils' / 'icons'
-            self.mkpath(str(target_dir))
-            icons_pyqt5 = target_dir / '_icons_pyqt5.py'
-            icons_pyside2 = target_dir / '_icons_pyside2.py'
-            qrc_file = Path('icons', 'icons.qrc')
-            check_call(['pyrcc5', '-o', str(icons_pyqt5), str(qrc_file)])
-            check_call(['pyside2-rcc', '-o', str(icons_pyside2), str(qrc_file)])
+            build_icons(target_dir)
         super().run()
+
+
+class custom_develop(develop):
+    def run(self):
+        if not self.dry_run:
+            target_dir = Path('.') / 'qtutils' / 'icons'
+            self.mkpath(str(target_dir))
+            build_icons(target_dir)
+        super().run()
+
 
 setup(
     use_scm_version={
         "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
         "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
     },
-    cmdclass={'build_py': build_py},
+    cmdclass={
+        'build_py': custom_build_py,
+        'develop': custom_develop,
+    },
 )


### PR DESCRIPTION
Neither of these were building icons.

It seems the develop and build_py commands need to be overridden
separately to ensure icons are build in both cases.

Not sure how this worked previously, perhaps it didn't.