### PR TITLE
Add Outputbox clearing options (#2)

### DIFF
--- a/qtutils/outputbox.py
+++ b/qtutils/outputbox.py
@@ -133,6 +133,9 @@ class OutputBox(object):
         self.shortcut = QShortcut(QKeySequence("Return"), self.output_textedit)
         self.shortcut.activated.connect(self.add_whitespace)
         
+        self.shortcut = QShortcut(QKeySequence("CTRL+L"), self.output_textedit)
+        self.shortcut.activated.connect(self.jump_to_end)
+        
         if zmq_context is None:
             zmq_context = zmq.Context.instance()
         self.zmq_context = zmq_context
@@ -354,6 +357,22 @@ class OutputBox(object):
         self.output_textedit.moveCursor(QTextCursor.End)
         self._text_queue.put(("\n", "default"))
         self.add_text() 
+        
+    def jump_to_end(self):
+        """Jumps to the end of outputbox and sets the last line as the top"""
+        
+        # Stores the last block
+        lastBlock = self.output_textedit.document().lastBlock()
+        lastLineText = lastBlock.text()
+        
+        # Clears
+        self.output_textedit.clear()
+
+        # Then tosses that block back to outputbox
+        self._text_queue.put((lastLineText, "default"))
+        self.add_text()
+
+        self.output_textedit.moveCursor(QTextCursor.End)
         
     def shutdown(self):
         """Stop the mainloop. Further writing to the OutputBox will be ignored. It is

--- a/qtutils/outputbox.py
+++ b/qtutils/outputbox.py
@@ -129,7 +129,10 @@ class OutputBox(object):
         self.output_textedit.setMaximumBlockCount(scrollback_lines)
         self.output_textedit.setContextMenuPolicy(Qt.CustomContextMenu)
         self.output_textedit.customContextMenuRequested.connect(self._show_context_menu)
-
+        
+        self.shortcut = QShortcut(QKeySequence("Return"), self.output_textedit)
+        self.shortcut.activated.connect(self.add_whitespace)
+        
         if zmq_context is None:
             zmq_context = zmq.Context.instance()
         self.zmq_context = zmq_context
@@ -344,6 +347,13 @@ class OutputBox(object):
             cursor.movePosition(QTextCursor.PreviousCharacter, n=charsprinted)
             cursor.movePosition(QTextCursor.End, QTextCursor.KeepAnchor)
             cursor.setCharFormat(charformats(charformat_repr))
+            
+    def add_whitespace(self):
+        """Blackspace actually? Jumps to end of the outputbox and adds an empty line."""
+        
+        self.output_textedit.moveCursor(QTextCursor.End)
+        self._text_queue.put(("\n", "default"))
+        self.add_text() 
         
     def shutdown(self):
         """Stop the mainloop. Further writing to the OutputBox will be ignored. It is

--- a/qtutils/outputbox.py
+++ b/qtutils/outputbox.py
@@ -127,6 +127,8 @@ class OutputBox(object):
         self.output_textedit.setWordWrapMode(QTextOption.WrapAnywhere)
         set_auto_scroll_to_end(self.output_textedit.verticalScrollBar())
         self.output_textedit.setMaximumBlockCount(scrollback_lines)
+        self.output_textedit.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.output_textedit.customContextMenuRequested.connect(self._show_context_menu)
 
         if zmq_context is None:
             zmq_context = zmq.Context.instance()
@@ -224,6 +226,26 @@ class OutputBox(object):
             color = WHITE
             bold = False
         self.write(text, color=color, bold=bold)
+
+    def _show_context_menu(self, pos):
+        menu = self.output_textedit.createStandardContextMenu()
+        menu.addSeparator()
+        clear_action = menu.addAction('Clear Output')
+        chosen = menu.exec(self.output_textedit.mapToGlobal(pos))
+        if chosen is clear_action:
+            self.clear_output()
+
+    @inmain_decorator(False)
+    def clear_output(self):
+        """Clear all text currently displayed in the output box by flushing 
+        queue and reset line-position."""
+        while True:
+            try:
+                self._text_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.output_textedit.clear()
+        self.linepos = self.LINE_NEW
 
     def mainloop(self, socket):
         while True:
@@ -346,7 +368,7 @@ class OutputBox(object):
         return False
 
     def flush(self):
-        pass
+        self.clear_output()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I tried having a go at #2 . This adds

1. a context menu option to clear the whole textbox
2. a return/enter shortcut to add a newline 
3. a ctrl+L shortcut to jump to the end

Although reading the issue again 
> Maybe also it should be that if you hit control-L, the window scrolls down past the last line so that the next printed line will be at the top.

Was this more intended to force a scroll and keeping the previous text to scroll back to later rather than clearing down to the last line? In which case 3. isn't quite right since it'll discard the entirety of the output and displays just the last line at the top, although I believe the built-in QT functions might be easier to leverage for the former. 